### PR TITLE
feat: Spring security API / Web 요청 분리, 지원하지 않는 Http method 요청시 405 응답

### DIFF
--- a/src/main/java/com/task/penta/config/AuthResponseUtil.java
+++ b/src/main/java/com/task/penta/config/AuthResponseUtil.java
@@ -1,0 +1,24 @@
+package com.task.penta.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+public class AuthResponseUtil {
+
+    public static void authResultResponseBody(HttpServletResponse response, int httpServletResponseStatusCode, String resultMessage) throws IOException {
+        response.setStatus(httpServletResponseStatusCode);
+//         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setContentType("application/json;charset=UTF-8");
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String jsonResponse = objectMapper.writeValueAsString(new AuthResultResponseDto(httpServletResponseStatusCode, resultMessage));
+        PrintWriter writer = response.getWriter();
+        writer.print(jsonResponse);
+        writer.flush();
+        writer.close();
+    }
+}

--- a/src/main/java/com/task/penta/config/AuthResultResponseDto.java
+++ b/src/main/java/com/task/penta/config/AuthResultResponseDto.java
@@ -1,0 +1,11 @@
+package com.task.penta.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class AuthResultResponseDto {
+    private final int status;
+    private final String message;
+}

--- a/src/main/java/com/task/penta/config/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/task/penta/config/CustomAccessDeniedHandler.java
@@ -1,0 +1,15 @@
+package com.task.penta.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import java.io.IOException;
+
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException {
+        AuthResponseUtil.authResultResponseBody(response, HttpServletResponse.SC_FORBIDDEN, "접근 권한이 없습니다.");
+    }
+}

--- a/src/main/java/com/task/penta/config/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/task/penta/config/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,16 @@
+package com.task.penta.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import java.io.IOException;
+
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        AuthResponseUtil.authResultResponseBody(response, HttpServletResponse.SC_UNAUTHORIZED, "인증에 실패 했습니다. 로그인이 필요합니다.");
+    }
+}

--- a/src/main/java/com/task/penta/config/WebSecurityConfig.java
+++ b/src/main/java/com/task/penta/config/WebSecurityConfig.java
@@ -34,25 +34,19 @@ public class WebSecurityConfig {
     private final UserDetailsServiceImpl userDetailsService;
     private final AuthenticationConfiguration authenticationConfiguration;
 
-    /**
-     * 비밀번호 암호화
-     */
+    // 비밀번호 암호화
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 
-    /**
-     * 인증 manager
-     */
+    // 인증 manager
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
         return configuration.getAuthenticationManager();
     }
 
-    /**
-     * 커스텀 인증 (Authentication) filter
-     */
+    // 커스텀 인증 (Authentication) filter
     @Bean
     public JwtAuthenticationFilter jwtAuthenticationFilter() throws Exception {
         JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtUtil);
@@ -60,30 +54,27 @@ public class WebSecurityConfig {
         return filter;
     }
 
-    /**
-     * 커스텀 인가 (Authorization) filter
-     */
+    // 커스텀 인가 (Authorization) filter
     @Bean
     public JwtAuthorizationFilter jwtAuthorizationFilter() {
         return new JwtAuthorizationFilter(jwtUtil, userDetailsService);
     }
 
-    /**
-     * 인증 (Authentication) 실패 핸들러
-     */
+    // 인증 (Authentication) 실패 핸들러
     @Bean
     public AuthenticationEntryPoint entryPoint() {
         return new CustomAuthenticationEntryPoint();
     }
 
-    /**
-     * 인가 (Authorization) 실패 핸들러
-     */
+    // 인가 (Authorization) 실패 핸들러
     @Bean
     public AccessDeniedHandler accessDeniedHandler() {
         return new CustomAccessDeniedHandler();
     }
 
+    /**
+     * Restful API security 설정 (/api/** 요청에만 적용됩니다.)
+     */
     @Bean
     @Order(1)
     public SecurityFilterChain ApiSecurityFilterChain(HttpSecurity http) throws Exception {
@@ -108,6 +99,9 @@ public class WebSecurityConfig {
         return http.build();
     }
 
+    /**
+     * Web security 설정 (api 를 제외한 모든 웹 요청 설정입니다.)
+     */
     @Bean
     @Order(2)
     public SecurityFilterChain WebSecurityFilterChain(HttpSecurity http) throws Exception {
@@ -141,8 +135,6 @@ public class WebSecurityConfig {
 
     /**
      * Spring security 공통 설정
-     * @param http
-     * @throws Exception
      */
     private void applyCommonSecurityConfig(HttpSecurity http) throws Exception {
         // CSRF 설정

--- a/src/main/java/com/task/penta/exception/ErrorCode.java
+++ b/src/main/java/com/task/penta/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     DUPLICATE_USER_ID(HttpStatus.CONFLICT, "중복된 회원 ID 입니다."),
     INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "유효하지 않은 파라미터입니다."),
+    HTTP_METHOD_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "지원하지 않는 HTTP Method 입니다."),
 
     ;
 

--- a/src/main/java/com/task/penta/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/task/penta/exception/GlobalExceptionHandler.java
@@ -21,7 +21,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<?>> handleExceptions(Exception e) {
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ApiResponse.createError(e.getMessage()));
+                .body(ApiResponse.createError(ErrorCode.INTERNAL_SERVER_ERROR.getMessage()));
     }
 
     // Bean validation exception
@@ -46,6 +46,6 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<?>> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
         return ResponseEntity
                 .status(HttpStatus.METHOD_NOT_ALLOWED)
-                .body(ApiResponse.createError(e.getMessage()));
+                .body(ApiResponse.createError(ErrorCode.HTTP_METHOD_NOT_ALLOWED.getMessage()));
     }
 }

--- a/src/main/java/com/task/penta/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/task/penta/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.task.penta.common.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -14,6 +15,14 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    // Interval exception
+    @ExceptionHandler
+    public ResponseEntity<ApiResponse<?>> handleExceptions(Exception e) {
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.createError(e.getMessage()));
+    }
 
     // Bean validation exception
     @ExceptionHandler
@@ -26,18 +35,17 @@ public class GlobalExceptionHandler {
     // CustomException 처리
     @ExceptionHandler
     public ResponseEntity<ApiResponse<?>> handleCustomException(CustomException e) {
-        log.info("-- CustomExceptionHandler -- ");
         ErrorCode errorCode = e.getErrorCode();
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
                 .body(ApiResponse.createError(errorCode.getMessage()));
     }
 
-    // Interval exception
+    // 405 Method Not Allowed / 요청 가능한 http method 외 요청이 왔을 경우
     @ExceptionHandler
-    public ResponseEntity<?> handleExceptions(Exception e) {
+    public ResponseEntity<ApiResponse<?>> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
         return ResponseEntity
-                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .status(HttpStatus.METHOD_NOT_ALLOWED)
                 .body(ApiResponse.createError(e.getMessage()));
     }
 }

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -5,11 +5,13 @@
     <meta name="viewport"
           content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <title>Document</title>
+    <title>Main Page</title>
 </head>
 <body>
     <header th:replace="~{fragments/header :: header}"></header>
 
+    <h1>Main Page</h1>
+    ADMIN 권한 계정 로그인 시, '회원 목록'을 볼 수 있는 링크가 아래 보입니다.
     <!-- SYSTEM_ADMIN 권한을 가지고 있다면 보임 -->
     <div sec:authorize="hasAuthority('SYSTEM_ADMIN')"><a th:href="@{/admin/users}">회원 목록</a></div>
 


### PR DESCRIPTION
- Spring security API와 Web 요청 security filter 분리
- RestAPI 요청에 지원하지 않는 HTTP method 요청 시, 405 Method Not Allowed 응답 하도록 추가