### PR TITLE
refactor: user history - try/catch로 분리

### DIFF
--- a/src/main/java/com/task/penta/common/CommonUtil.java
+++ b/src/main/java/com/task/penta/common/CommonUtil.java
@@ -4,6 +4,7 @@ import jakarta.servlet.http.HttpServletRequest;
 
 public class CommonUtil {
 
+    // 클라이언트 IP 가져오기
     public static String getClientIp(HttpServletRequest request) {
         String ip = request.getHeader("X-Forwarded-For");
 
@@ -38,5 +39,17 @@ public class CommonUtil {
 //        }
 
         return ip;
+    }
+
+    // 클라이언트 요청 url 가져오기
+    public static String getRequestUrl(HttpServletRequest request) {
+        // 전체 URL을 가져오기
+        String requestUrl = request.getRequestURL().toString();
+        String queryString = request.getQueryString(); // 쿼리 문자열 가져오기
+        if (queryString != null) {
+            requestUrl += "?" + queryString; // 쿼리 문자열이 있을 경우 URL에 추가
+        }
+
+        return requestUrl;
     }
 }

--- a/src/main/java/com/task/penta/controller/api/SystemUserController.java
+++ b/src/main/java/com/task/penta/controller/api/SystemUserController.java
@@ -64,7 +64,8 @@ public class SystemUserController {
             @Valid @RequestBody UserCreateRequestDto requestDto,
             HttpServletRequest request) {
         String clientIp = getClientIp(request);
-        UserCreateResponseDto createdUser = systemUserService.createUser(requestDto, clientIp);
+        String requestUrl = getRequestUrl(request);
+        UserCreateResponseDto createdUser = systemUserService.createUser(requestDto, clientIp, requestUrl);
 
         return ApiResponse.createSuccess(createdUser);
     }
@@ -81,7 +82,8 @@ public class SystemUserController {
             @Valid @RequestBody UserUpdateRequestDto requestDto,
             HttpServletRequest request) {
         String clientIp = getClientIp(request);
-        UserUpdateResponseDto updatedUser = systemUserService.updateUser(userId, requestDto, clientIp);
+        String requestUrl = getRequestUrl(request);
+        UserUpdateResponseDto updatedUser = systemUserService.updateUser(userId, requestDto, clientIp, requestUrl);
 
         return ApiResponse.createSuccess(updatedUser);
     }
@@ -95,7 +97,8 @@ public class SystemUserController {
     public ApiResponse<UserDeleteResponseDto> deleteUser(
             @PathVariable String userId, HttpServletRequest request) {
         String clientIp = getClientIp(request);
-        UserDeleteResponseDto deletedUser = systemUserService.deleteUser(userId, clientIp);
+        String requestUrl = getRequestUrl(request);
+        UserDeleteResponseDto deletedUser = systemUserService.deleteUser(userId, clientIp, requestUrl);
 
         return ApiResponse.createSuccess(deletedUser);
     }
@@ -103,5 +106,10 @@ public class SystemUserController {
     // 클라이언트 ip 가져오기
     private static String getClientIp(HttpServletRequest request) {
         return CommonUtil.getClientIp(request);
+    }
+
+    // 클라이언트 requestUrl 가져오기
+    private static String getRequestUrl(HttpServletRequest request) {
+        return CommonUtil.getRequestUrl(request);
     }
 }

--- a/src/main/java/com/task/penta/controller/api/SystemUserController.java
+++ b/src/main/java/com/task/penta/controller/api/SystemUserController.java
@@ -1,7 +1,6 @@
 package com.task.penta.controller.api;
 
 import com.task.penta.common.ApiResponse;
-import com.task.penta.common.CommonUtil;
 import com.task.penta.dto.request.UserCreateRequestDto;
 import com.task.penta.dto.request.UserUpdateRequestDto;
 import com.task.penta.dto.response.UserCreateResponseDto;
@@ -15,6 +14,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+
+import static com.task.penta.common.CommonUtil.getClientIp;
+import static com.task.penta.common.CommonUtil.getRequestUrl;
 
 @RestController
 @RequiredArgsConstructor
@@ -101,15 +103,5 @@ public class SystemUserController {
         UserDeleteResponseDto deletedUser = systemUserService.deleteUser(userId, clientIp, requestUrl);
 
         return ApiResponse.createSuccess(deletedUser);
-    }
-
-    // 클라이언트 ip 가져오기
-    private static String getClientIp(HttpServletRequest request) {
-        return CommonUtil.getClientIp(request);
-    }
-
-    // 클라이언트 requestUrl 가져오기
-    private static String getRequestUrl(HttpServletRequest request) {
-        return CommonUtil.getRequestUrl(request);
     }
 }

--- a/src/test/java/com/task/penta/service/SystemUserServiceTest.java
+++ b/src/test/java/com/task/penta/service/SystemUserServiceTest.java
@@ -16,6 +16,7 @@ class SystemUserServiceTest {
     private SystemUserService systemUserService;
 
     private static final String CLIENT_IP = "127.0.0.1";
+    private static final String REQUEST_URL = "http://example.com";
 
     @Test
     @DisplayName("일반 회원 생성 테스트")
@@ -29,7 +30,7 @@ class SystemUserServiceTest {
                         "테스트일반회원",
                         "user"
                 );
-        UserCreateResponseDto savedNormalUser = systemUserService.createUser(requestDto, CLIENT_IP);
+        UserCreateResponseDto savedNormalUser = systemUserService.createUser(requestDto, CLIENT_IP, REQUEST_URL);
 
         // 검증
         assertThat(savedNormalUser.getUserId()).isEqualTo("usertest");
@@ -50,7 +51,7 @@ class SystemUserServiceTest {
                         "admin"
                 );
 
-        UserCreateResponseDto savedAdminUser = systemUserService.createUser(requestDto, CLIENT_IP);
+        UserCreateResponseDto savedAdminUser = systemUserService.createUser(requestDto, CLIENT_IP, REQUEST_URL);
 
         // 검증
         assertThat(savedAdminUser.getUserId()).isEqualTo("admintest");


### PR DESCRIPTION
- user history와 회원 추가, 수정, 삭제가 같은 트랜잭션에 있어서 히스토리 기록에 예외가 발생할 경우, 회원의 로직이 롤백되는 것을 막기 위함
- 히스토리 기록에 예외가 발생할 경우 log를 남기도록 추가